### PR TITLE
Make sidebar more responsive on windows with small heights

### DIFF
--- a/src/pages/home/home.styles.scss
+++ b/src/pages/home/home.styles.scss
@@ -9,7 +9,8 @@
 
 .side-bar {
     width: 200px; 
-    position: relative;
+    height: 100vh;
+    position: sticky;
     z-index: 10; 
     top: 0; 
     left: 0;

--- a/src/pages/home/home.styles.scss
+++ b/src/pages/home/home.styles.scss
@@ -9,6 +9,7 @@
 
 .side-bar {
     width: 200px; 
+    min-width: 200px;
     height: 100vh;
     position: sticky;
     z-index: 10; 

--- a/src/pages/home/home.styles.scss
+++ b/src/pages/home/home.styles.scss
@@ -4,17 +4,16 @@
 }
 
 .job-stuffs {
-    width: 100%;
-    margin-left: 200px;
+    flex-grow: 1;
 }
 
 .side-bar {
-    height: 100%;
     width: 200px; 
-    position: fixed;
+    position: relative;
     z-index: 10; 
-    top: 25; 
+    top: 0; 
     left: 0;
+    padding: 20px 0;
     overflow-x: hidden; 
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
I changed a few lines in home.styles.scss to make it so the sidebar is visible at all times and take better advantage of flexbox. I'm sure what your build process is, so I only changed the one scss file for now.

- Removed `width` and `margin` from `.job-stuff` and replaced with `flex-grow: 1` which will accomplish the same thing.
- Set `position` of `.side-bar` to `sticky` instead of `fixed` and set `top` to `0` which results in the sidebar scrolling with the main content until it hits the top of the window.
- Set `height` of `.side-bar` to `100vh` instead of `100%` which results in the sidebar having the full window height instead of inheriting height from its parent.  
- Added a little padding to the top and bottom of the sidebar.

To see the new sidebar behavior, it's easiest to make your browser window height artificially small. 

Fixes #12 