### PR TITLE
Validation for "Add Interaction"

### DIFF
--- a/src/components/AddInteractionRow/AddInteractionRow.jsx
+++ b/src/components/AddInteractionRow/AddInteractionRow.jsx
@@ -11,30 +11,48 @@ import { addInteractionToJob } from '../../firebase/firebase.utils'
 import Form from "react-bootstrap/Form";
 
 const AddInteractionRow = (props) => {
-   const [ date, setDate ] = useState('')
+	 const [ date, setDate ] = useState('')
    const [ type, setType ] = useState('')
+	 const [ dateValidated, setDateValidated ] = useState(true)
+	 const [ typeValidated, setTypeValidated ] = useState(true)
+
    const [ nextSteps, setNextSteps ] = useState('')
 
 	const handleSubmit = () => {
-      let interaction = {
-         date, type, nextSteps
-      }
-      addInteractionToJob(interaction);
-      props.changeShowAddInteraction();
+			if (date && type) {
+					let interaction = { date, type, nextSteps }
+					addInteractionToJob(interaction);
+					props.changeShowAddInteraction();
+			}
+			if (!date) setDateValidated(false)
+			else setDateValidated(true)
+
+			if (!type) setTypeValidated(false)
+			else setTypeValidated(true)
 	};
 	return (
 		<tr>
 			<td>
-				<Form.Control type="date" value={date} onChange={(e) => setDate(e.target.value)}></Form.Control>
+				<Form.Control 
+					className={dateValidated ? '' : 'is-invalid'} 
+					type="date" 
+					value={date} 
+					onChange={(e) => setDate(e.target.value)}
+				/>
 			</td>
 			<td>
-				<Form.Control as='select' value={type} onChange={(e) => setType(e.target.value)}>
-                  <option disabled defaultValue></option>
-						<option value="emailed">Emailed</option>
-						<option value="call">Call</option>
-						<option value="code challenge">Code challenge</option>
-						<option value="interviewed">Interviewed</option>
-            </Form.Control>
+				<Form.Control 
+					className={typeValidated ? '' : 'is-invalid'} 
+					as='select' 
+					value={type} 
+					onChange={(e) => setType(e.target.value)}
+				>
+					<option disabled defaultValue></option>
+					<option value="emailed">Emailed</option>
+					<option value="call">Call</option>
+					<option value="code challenge">Code challenge</option>
+					<option value="interviewed">Interviewed</option>
+				</Form.Control>
 			</td>
 			<td>
 				<Form.Control type="text" value={nextSteps} onChange={(e) => setNextSteps(e.target.value)}></Form.Control>


### PR DESCRIPTION
Depends on Bootstrap's 'is-validated' class, which outlines an input. It is a bit hacky, but w/e. 

Previously, you could add an interaction with no date, which changed the displayed date on the main page to "undefined/undefined." I added some very basic form validation.

Note that the validation used elsewhere (making the Form.Control required, like in `add-job.component.jsx`) does not work here, as the inputs are not wrapped by a form. They can't be, because they are in a table.

**NOTE** this bug also exists in `InteractionRow` edit option, as well as `JobRow` edit button/select job. Both of these are MUCH less likely to run into user error, and I didn't feel like diving into your Redux code.