### PR TITLE
Enforce keys on elements of tables

### DIFF
--- a/src/components/InteractionTable/InteractionTable.jsx
+++ b/src/components/InteractionTable/InteractionTable.jsx
@@ -26,11 +26,10 @@ function InteractionTable(props){
                
             {props.interactions? props.interactions.map((interaction) => {
                                  return (
-                                    <>
                                        <InteractionRow
+                                       key={interaction.id}
                                        interaction={interaction}
                                        />
-                                    </>
                                  )
                            }) : null}
             </tbody>

--- a/src/components/JobsTable/JobsTable.jsx
+++ b/src/components/JobsTable/JobsTable.jsx
@@ -64,15 +64,12 @@ function JobsTable(props){
                         <tbody id="job-table-body">
                            {filteredJobs ? filteredJobs.map((job) => {
                                  return (
-                                    <>
                                        <JobRow 
                                        key={job.id} 
                                        handleOpen={handleOpen}
                                        handleClose={handleClose} 
                                        job={job}
                                        />
-                                       
-                                    </>
                                  )
                            }) : null}
                         </tbody>


### PR DESCRIPTION
I also don't believe the React Fragments are needed, because they only contain one element? I may be wrong.